### PR TITLE
Changed shift method in ZLP subpixel align to scipy.ndimage.shift wit…

### DIFF
--- a/nionswift_plugin/nion_eels_analysis/AlignZLP.py
+++ b/nionswift_plugin/nion_eels_analysis/AlignZLP.py
@@ -92,8 +92,7 @@ def align_zlp_xdata_subpixel(src_xdata: DataAndMetadata.DataAndMetadata, progres
                 mx_pos = numpy.argmax(flat_src_data[i])
             # determine the offset and apply it
             offset = ref_pos - mx_pos
-            src_data_fft = numpy.fft.fftn(flat_src_data[i])
-            flat_dst_data[i] = numpy.fft.ifftn(scipy.ndimage.fourier_shift(src_data_fft, offset)).real
+            flat_dst_data[i] = scipy.ndimage.shift(flat_src_data[i], offset, order=1)
             # every row, report progress (will also work for a sequence or 1d collection
             # because there we have only 1 row anyways)
             if i % src_shape[1] == 0 and callable(progress_fn):
@@ -178,3 +177,4 @@ def align_zlp_fit(api, window):
             print("Failed: Data is not a sequence or collection of 1D spectra.")
     else:
         print("Failed: No data item selected.")
+


### PR DESCRIPTION
…h linear interpolation to get rid of artifacts.

Matt showed me a dataset that had some artifacts in it after using subpixel ZLP align (see here: https://drive.google.com/file/d/1vIZJBwQRZIoZhSbFn_wwN7BzqfSZ8YIX/view?usp=sharing). This periodic pattern that is on top of the data comes from the scipy.ndimage.fftshift method. When using scipy.ndimage.shift with interpolation oder 1 (i.e. linear interpolation) the artifacts are gone. I don't think this interpolation method has any negative effects, so it should be safe to merge.