### PR TITLE
Added exponential functions for two area method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog (nionswift-eels-analysis)
 0.5.1 (UNRELEASED):
 -------------------
 - Add Two-Area background fitting class.
+- Add exponential functions for two-area method.
 
 0.5.0 (2020-08-31):
 -------------------


### PR DESCRIPTION
It turns out that the exponential method is based on the geometric mean, rather than the area, of the two intervals. To accommodate that, I changed to TwoAreaBackgroundModel class to pass the intervals rather than the area to the params functions. Arguably, the class name should be changed to TwoIntervalBackgroundModel.