### PR TITLE
fixing typo to use internal transform functions of polyfit class

### DIFF
--- a/nion/eels_analysis/BackgroundModel.py
+++ b/nion/eels_analysis/BackgroundModel.py
@@ -117,8 +117,8 @@ class PolynomialBackgroundModel(AbstractBackgroundModel):
     def _perform_fits(self, xs: numpy.ndarray, yss: numpy.ndarray, fs: numpy.ndarray) -> numpy.ndarray:
         transform_data = self.transform or (lambda x: x)
         untransform_data = self.untransform or (lambda x: x)
-        ceofficients = numpy.polynomial.polynomial.polyfit(self.transform(xs), transform_data(yss.transpose()), self.deg)
-        fit = untransform_data(numpy.polynomial.polynomial.polyval(self.transform(fs), ceofficients))
+        ceofficients = numpy.polynomial.polynomial.polyfit(transform_data(xs), transform_data(yss.transpose()), self.deg)
+        fit = untransform_data(numpy.polynomial.polynomial.polyval(transform_data(fs), ceofficients))
         return numpy.where(numpy.isfinite(fit), fit, 0)
 
     def __unused_perform_fit(self, xs: numpy.ndarray, ys: numpy.ndarray, fs: numpy.ndarray) -> numpy.ndarray:


### PR DESCRIPTION
Previously I mistakenly used self.transform instead of the class method transform_data, which falls back to a lambda identity function if no transform is provided. 