### PR TITLE
Improve zlp analyis

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog (nionswift-eels-analysis)
 0.5.3 (unreleased):
 -------------------
 - Fix issue with Align ZLP (COM) when using it on empty data.
+- Fix issue with Align ZLP (COM) that caused a bias towards half-integer shifts.
+- Allow Align ZLP to be used on single spectra. Useful for bringing the ZLP to calibrated zero.
 
 0.5.2 (2020-11-13):
 -------------------

--- a/nion/eels_analysis/ZLP_Analysis.py
+++ b/nion/eels_analysis/ZLP_Analysis.py
@@ -49,8 +49,16 @@ def estimate_zlp_amplitude_position_width_com(d):
     assert len(d.shape) == 1
     mx_pos = numpy.argmax(d)
     mx = d[mx_pos]
-    half_mx = mx/2
-    left_pos = mx_pos - numpy.sum(d[:mx_pos] > half_mx)
-    right_pos = mx_pos + numpy.sum(d[mx_pos:] > half_mx)
-    mx_pos_sub = numpy.sum(d[left_pos:right_pos] * numpy.arange(right_pos - left_pos))/(numpy.sum(d[left_pos:right_pos]) or 1)
-    return mx, mx_pos_sub + left_pos, left_pos, right_pos
+    quarter_max = mx * 0.25
+    left_pos = mx_pos - numpy.sum(d[:mx_pos] > quarter_max) * 3
+    right_pos = mx_pos + numpy.sum(d[mx_pos:] > quarter_max) * 3
+    left_pos = max(0, left_pos)
+    right_pos = min(d.size, right_pos)
+    d_sub = d[left_pos:right_pos] - quarter_max
+    d_sub[d_sub < 0] = 0
+    mx_pos_sub = numpy.sum(d_sub * numpy.arange(right_pos - left_pos))/(numpy.sum(d_sub) or 1)
+    # Also calculate FWHM because it is used by some users of this function
+    half_max = mx * 0.5
+    left_end = mx_pos - numpy.sum(d[:mx_pos] > half_max)
+    right_end = mx_pos + numpy.sum(d[mx_pos:] > half_max)
+    return mx, mx_pos_sub + left_pos, left_end, right_end

--- a/nion/eels_analysis/test/ZLP_analysis_test.py
+++ b/nion/eels_analysis/test/ZLP_analysis_test.py
@@ -20,13 +20,13 @@ class TestZLPAnalysis(unittest.TestCase):
     def test_estimate_zlp_amplitude_position_width_com(self):
         max_pos_in = 61.523
         max_height_in = 1e3
-        HWHM_in = 8.225
-        data = ZLP_Analysis.gaussian(numpy.arange(512.0), max_height_in, max_pos_in, HWHM_in)
+        FWHM_in = 8.225
+        data = ZLP_Analysis.gaussian(numpy.arange(512.0), max_height_in, max_pos_in, FWHM_in)
         max_height, max_pos, left_pos, right_pos = ZLP_Analysis.estimate_zlp_amplitude_position_width_com(data)
         # com is not as accurate, so have to reduces precision
         self.assertAlmostEqual(max_pos, max_pos_in, places=1)
         self.assertAlmostEqual(max_height, max_height_in, delta=2)
-        self.assertAlmostEqual(HWHM_in, (right_pos - left_pos)/2, delta=2)
+        self.assertAlmostEqual(FWHM_in, (right_pos - left_pos)/2, delta=2)
 
     def test_estimate_zlp_amplitude_position_width_fails_with_2D_data(self):
         data = numpy.zeros((4, 4), numpy.float)


### PR DESCRIPTION
- Fix issue with Align ZLP (COM) that caused a bias towards half-integer shifts.
- Allow Align ZLP to be used on single spectra. Useful for bringing the ZLP to calibrated zero.