### PR TITLE
Change the numpy prod to math prod to fix typing

### DIFF
--- a/nion/eels_analysis/BackgroundModel.py
+++ b/nion/eels_analysis/BackgroundModel.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import copy
 import functools
 import gettext
+import math
 import numpy
 import scipy
 import scipy.integrate
@@ -121,7 +122,7 @@ class AbstractBackgroundModel:
         fs = numpy.linspace(interval_start, interval_end, n, dtype=numpy.float32)
         if spectrum_xdata.is_navigable:
             calibrations = list(copy.deepcopy(spectrum_xdata.navigation_dimensional_calibrations)) + [calibration]
-            yss = numpy.reshape(ys, (numpy.prod(ys.shape[:-1]),) + (ys.shape[-1],))
+            yss = numpy.reshape(ys, (math.prod(ys.shape[:-1]),) + (ys.shape[-1],))
             fit_data = self._perform_fits(xs, yss, fs, es)
             data_descriptor = DataAndMetadata.DataDescriptor(False, spectrum_xdata.navigation_dimension_count,
                                                              spectrum_xdata.datum_dimension_count)

--- a/nion/eels_analysis/PeakModel.py
+++ b/nion/eels_analysis/PeakModel.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 # imports
 import copy
 import gettext
+import math
 import numpy
 import typing
 
@@ -33,7 +34,7 @@ class AbstractZeroLossPeakModel:
         ys = spectrum_xdata.data
         if spectrum_xdata.is_navigable:
             calibrations = list(copy.deepcopy(spectrum_xdata.navigation_dimensional_calibrations)) + [calibration]
-            yss = numpy.reshape(ys, (numpy.prod(ys.shape[:-1]),) + (ys.shape[-1],))
+            yss = numpy.reshape(ys, (math.prod(ys.shape[:-1]),) + (ys.shape[-1],))
             fit_data = self._perform_fits(yss, z)
             data_descriptor = DataAndMetadata.DataDescriptor(False, spectrum_xdata.navigation_dimension_count,
                                                              spectrum_xdata.datum_dimension_count)


### PR DESCRIPTION
The update to numpy broke the type checks similar to https://github.com/nion-software/nionswift/pull/1884.
The error by mypy was 
```
nion\eels_analysis\BackgroundModel.py:124: error: Value of type variable "ShapeT" of "reshape" cannot be "tuple[float64, Any]"  [type-var]
```
The numpy.prod was broad so I changed it to the math.prod instead.