### PR TITLE
Use the label visibility and background color properties

### DIFF
--- a/nionswift_plugin/nion_eels_analysis/LiveThickness.py
+++ b/nionswift_plugin/nion_eels_analysis/LiveThickness.py
@@ -66,6 +66,7 @@ class MeasureThickness:
             thickness_interval.graphic_id = "thickness_interval"
             thickness_interval.label = f"{self.__thickness:0.4f}"
             thickness_interval._graphic.color = "#CE00AC"
+            thickness_interval._graphic.role = "measurement"
 
 
 ComputationCallable = typing.Callable[[Symbolic._APIComputation], Symbolic.ComputationHandlerLike]

--- a/nionswift_plugin/nion_eels_analysis/LiveZLP.py
+++ b/nionswift_plugin/nion_eels_analysis/LiveZLP.py
@@ -47,8 +47,7 @@ class MeasureZLP:
             zlp_interval.interval = start, end
             zlp_interval.graphic_id = "zlp_interval"
             zlp_interval._graphic.color = "black"
-            zlp_interval._graphic.text_visibility = "always"
-            zlp_interval._graphic.text_background_color = "white"
+            zlp_interval._graphic.role = "measurement"
 
 ComputationCallable = typing.Callable[[Symbolic._APIComputation], Symbolic.ComputationHandlerLike]
 

--- a/nionswift_plugin/nion_eels_analysis/LiveZLP.py
+++ b/nionswift_plugin/nion_eels_analysis/LiveZLP.py
@@ -47,6 +47,8 @@ class MeasureZLP:
             zlp_interval.interval = start, end
             zlp_interval.graphic_id = "zlp_interval"
             zlp_interval._graphic.color = "black"
+            zlp_interval._graphic.text_visibility = "always"
+            zlp_interval._graphic.text_background_color = "white"
 
 ComputationCallable = typing.Callable[[Symbolic._APIComputation], Symbolic.ComputationHandlerLike]
 


### PR DESCRIPTION
Fixes https://github.com/nion-software/nion-internal/issues/304.
Requires https://github.com/nion-software/nionswift/pull/1883.
Sets the text background to white for readability and makes the interval always show the text so it doesn't have to be selected.
